### PR TITLE
refine(ui): 首页与播放器视觉精修（对比度 / 层级 / reduced-motion）

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -383,9 +383,29 @@
   box-shadow: 0 20px 50px rgba(0, 0, 0, 0.3);
 }
 
-/* Smooth Scroll */
-html {
-  scroll-behavior: smooth;
+/* Smooth Scroll - only when the user has no motion preference */
+@media (prefers-reduced-motion: no-preference) {
+  html {
+    scroll-behavior: smooth;
+  }
+}
+
+/* Reduced Motion - disable decorative animations for sensitive users */
+@media (prefers-reduced-motion: reduce) {
+  .animate-equalizer,
+  .animate-spin-slow,
+  .animate-breathe,
+  .animate-pulse-subtle,
+  .animate-pulse-glow,
+  .animate-shimmer,
+  .animate-gradient {
+    animation: none;
+  }
+
+  /* Keep equalizer bars visible as a static state indicator */
+  .animate-equalizer {
+    transform: scaleY(0.6);
+  }
 }
 
 /* Better Font Rendering */

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -92,7 +92,7 @@ const LiveClock = memo(({ isDark, stationColor, isPlaying }: { isDark: boolean; 
             animation: isPlaying ? 'pulse 2s ease-in-out infinite' : 'none'
           }}
         />
-        <span className={cn("text-xs font-medium tracking-widest uppercase", isDark ? "text-white/38" : "text-zinc-600")}>
+        <span className={cn("text-xs font-medium tracking-widest uppercase", isDark ? "text-white/55" : "text-zinc-600")}>
           {clock.greeting}
         </span>
       </div>
@@ -119,7 +119,7 @@ const LiveClock = memo(({ isDark, stationColor, isPlaying }: { isDark: boolean; 
           {clock.s}
         </span>
       </div>
-      <span className={cn("text-xs mt-1.5 tracking-wide", isDark ? "text-white/34" : "text-zinc-600")}>
+      <span className={cn("text-xs mt-1.5 tracking-wide", isDark ? "text-white/50" : "text-zinc-600")}>
         {clock.date}
       </span>
     </motion.div>
@@ -189,7 +189,7 @@ const NavBar = memo(({ isDark, isPlaying, currentStation, stationColor, onThemeT
           </motion.div>
         ) : (
           <motion.div key="idle" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className="px-2 py-1">
-            <span className={cn("text-xs whitespace-nowrap", isDark ? "text-white/35" : "text-zinc-400")}>未播放</span>
+            <span className={cn("text-xs whitespace-nowrap", isDark ? "text-white/50" : "text-zinc-400")}>未播放</span>
           </motion.div>
         )}
       </AnimatePresence>
@@ -234,7 +234,7 @@ const FeatureCard = memo(({ feature, isDark }: { feature: typeof features[0]; is
       <feature.icon className="w-5 h-5" style={{ color: feature.color }} />
     </div>
     <h3 className={cn("relative text-base font-semibold mb-1.5", isDark ? "text-white/90" : "text-zinc-900")}>{feature.title}</h3>
-    <p className={cn("relative text-sm leading-relaxed", isDark ? "text-white/38" : "text-zinc-500")}>{feature.description}</p>
+    <p className={cn("relative text-sm leading-relaxed", isDark ? "text-white/55" : "text-zinc-500")}>{feature.description}</p>
   </motion.div>
 ));
 FeatureCard.displayName = 'FeatureCard';
@@ -255,7 +255,7 @@ const SceneCard = memo(({ scene, isDark, onClick }: { scene: typeof scenes[0]; i
     <div className="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none" style={{ background: `radial-gradient(ellipse at 50% 100%, ${scene.color}12 0%, transparent 65%)` }} />
     <div className="text-3xl mb-3 relative">{scene.icon}</div>
     <h4 className={cn("font-semibold text-sm mb-1 relative", isDark ? "text-white/90" : "text-zinc-900")}>{scene.title}</h4>
-    <p className={cn("text-xs leading-relaxed relative", isDark ? "text-white/38" : "text-zinc-500")}>{scene.description}</p>
+    <p className={cn("text-xs leading-relaxed relative", isDark ? "text-white/55" : "text-zinc-500")}>{scene.description}</p>
   </motion.button>
 ));
 SceneCard.displayName = 'SceneCard';
@@ -294,7 +294,7 @@ const StationCard = memo(({ station, isDark, isActive, isPlaying, onClick }: {
           {station.name}
         </h4>
         <div className="flex items-center gap-1 mt-0.5">
-          <span className={cn("text-xs", isDark ? "text-white/30" : "text-zinc-400")}>{station.style1}</span>
+          <span className={cn("text-xs", isDark ? "text-white/45" : "text-zinc-400")}>{station.style1}</span>
           {station.custom && (
             <>
               <span className={cn("text-xs", isDark ? "text-white/15" : "text-zinc-300")}>·</span>
@@ -476,7 +476,7 @@ export default function Home() {
               </motion.div>
 
               {/* 标题 */}
-              <motion.h1 variants={fadeInUp} className="text-3xl sm:text-5xl md:text-6xl lg:text-7xl font-bold leading-[1.1] mb-5 whitespace-nowrap">
+              <motion.h1 variants={fadeInUp} className="text-3xl sm:text-5xl md:text-6xl lg:text-7xl font-bold leading-[1.15] mb-5 text-balance">
                 <span className={cn(
                   "bg-clip-text text-transparent",
                   isDark
@@ -489,7 +489,7 @@ export default function Home() {
 
               {/* 描述 */}
               <motion.p variants={fadeInUp} className={cn("text-base sm:text-lg md:text-xl max-w-2xl mx-auto mb-10 leading-relaxed", isDark ? "text-white/45" : "text-zinc-500")}>
-                Lofi 音乐被科学认证为最适合专注工作学习的音乐。
+                恰到好处的 Lofi 节拍，陪伴你进入深度专注。
                 <br className="hidden sm:block" />
                 macOS 灵动岛设计，{stations.length} 个精选电台，打开即用，无需下载。
               </motion.p>
@@ -520,7 +520,7 @@ export default function Home() {
                   {shortcuts.map((item, i) => (
                     <div key={i} className="flex items-center gap-1.5">
                       <kbd className={cn("px-2 py-0.5 rounded-md text-xs font-mono font-semibold", isDark ? "bg-white/10 text-white/50 border border-white/10" : "bg-black/5 text-zinc-500 border border-black/8")}>{item.key}</kbd>
-                      <span className={cn("text-xs", isDark ? "text-white/30" : "text-zinc-400")}>{item.label}</span>
+                      <span className={cn("text-xs", isDark ? "text-white/45" : "text-zinc-400")}>{item.label}</span>
                     </div>
                   ))}
                 </div>
@@ -617,7 +617,7 @@ export default function Home() {
           <div className="max-w-5xl mx-auto">
             <motion.div initial={{ opacity: 0, y: 15 }} whileInView={{ opacity: 1, y: 0 }} viewport={{ once: true }} transition={{ duration: 0.5 }} className="text-center mb-10">
               <h2 className={cn("text-2xl sm:text-3xl font-bold mb-3", isDark ? "text-white" : "text-zinc-900")}>为什么选择 Lofi Radio</h2>
-              <p className={cn("text-base sm:text-lg max-w-xl mx-auto", isDark ? "text-white/38" : "text-zinc-500")}>专为专注设计，让音乐成为你工作和学习的最佳伴侣</p>
+              <p className={cn("text-base sm:text-lg max-w-xl mx-auto", isDark ? "text-white/55" : "text-zinc-500")}>专为专注设计，让音乐成为你工作和学习的最佳伴侣</p>
             </motion.div>
             <motion.div initial="hidden" whileInView="visible" viewport={{ once: true, margin: "-50px" }} variants={stagger} className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
               {features.map((f) => <FeatureCard key={f.title} feature={f} isDark={isDark} />)}
@@ -630,7 +630,7 @@ export default function Home() {
           <div className="max-w-5xl mx-auto">
             <motion.div initial={{ opacity: 0, y: 15 }} whileInView={{ opacity: 1, y: 0 }} viewport={{ once: true }} transition={{ duration: 0.5 }} className="text-center mb-10">
               <h2 className={cn("text-2xl sm:text-3xl font-bold mb-3", isDark ? "text-white" : "text-zinc-900")}>适用场景</h2>
-              <p className={cn("text-base sm:text-lg", isDark ? "text-white/38" : "text-zinc-500")}>无论学习、工作还是放松，总有一个电台适合你</p>
+              <p className={cn("text-base sm:text-lg", isDark ? "text-white/55" : "text-zinc-500")}>无论学习、工作还是放松，总有一个电台适合你</p>
             </motion.div>
             <motion.div initial="hidden" whileInView="visible" viewport={{ once: true }} variants={stagger} className="grid grid-cols-2 sm:grid-cols-4 gap-3 sm:gap-4">
               {scenes.map((s) => <SceneCard key={s.title} scene={s} isDark={isDark} onClick={() => handleSceneClick(s.id)} />)}
@@ -643,7 +643,7 @@ export default function Home() {
           <div className="max-w-5xl mx-auto">
             <motion.div initial={{ opacity: 0, y: 15 }} whileInView={{ opacity: 1, y: 0 }} viewport={{ once: true }} transition={{ duration: 0.5 }} className="text-center mb-10">
               <h2 className={cn("text-2xl sm:text-3xl font-bold mb-3", isDark ? "text-white" : "text-zinc-900")}>精选电台</h2>
-              <p className={cn("text-base sm:text-lg", isDark ? "text-white/38" : "text-zinc-500")}>涵盖多种风格，总有适合你的音乐</p>
+              <p className={cn("text-base sm:text-lg", isDark ? "text-white/55" : "text-zinc-500")}>涵盖多种风格，总有适合你的音乐</p>
             </motion.div>
             <motion.div initial="hidden" whileInView="visible" viewport={{ once: true }} variants={stagger} className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
               {stations.slice(0, 8).map((station) => (
@@ -697,7 +697,7 @@ export default function Home() {
                 </span>
               </div>
               <h2 className={cn("text-2xl sm:text-3xl font-bold mb-3", isDark ? "text-white" : "text-zinc-900")}>Lofi Radio 常见问题</h2>
-              <p className={cn("text-sm sm:text-base max-w-3xl mx-auto leading-relaxed", isDark ? "text-white/38" : "text-zinc-500")}>把使用时最容易遇到的几个问题整理在这里，既方便第一次打开网站时快速了解，也能帮你更快找到适合自己的收听方式和使用场景。</p>
+              <p className={cn("text-sm sm:text-base max-w-3xl mx-auto leading-relaxed", isDark ? "text-white/55" : "text-zinc-500")}>把使用时最容易遇到的几个问题整理在这里，既方便第一次打开网站时快速了解，也能帮你更快找到适合自己的收听方式和使用场景。</p>
             </motion.div>
 
             <motion.div

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -75,7 +75,7 @@ const LiveClock = memo(({ isDark, stationColor, isPlaying }: { isDark: boolean; 
       animate={{ opacity: 1, scale: 1 }}
       transition={{ duration: 0.6, delay: 0.3 }}
       className={cn(
-        "inline-flex flex-col items-center px-8 py-5 rounded-3xl mb-8",
+        "inline-flex flex-col items-center px-6 py-4 rounded-3xl mb-8",
         isDark ? "bg-white/[0.03]" : "bg-black/[0.02]"
       )}
       style={{
@@ -98,7 +98,7 @@ const LiveClock = memo(({ isDark, stationColor, isPlaying }: { isDark: boolean; 
       </div>
       <div className="flex items-baseline gap-1.5">
         <span
-          className="text-5xl sm:text-6xl font-bold tabular-nums tracking-tight"
+          className="text-4xl sm:text-5xl font-bold tabular-nums tracking-tight"
           style={{
             backgroundImage: timeGradient,
             WebkitBackgroundClip: 'text',
@@ -110,7 +110,7 @@ const LiveClock = memo(({ isDark, stationColor, isPlaying }: { isDark: boolean; 
           {clock.h}:{clock.m}
         </span>
         <span
-          className="text-2xl font-semibold tabular-nums self-end pb-1"
+          className="text-xl font-semibold tabular-nums self-end pb-1"
           style={{
             color: isDark ? `${stationColor}d6` : stationColor,
             textShadow: isDark ? `0 0 14px ${stationColor}40` : 'none'
@@ -130,9 +130,9 @@ LiveClock.displayName = 'LiveClock';
 // ==================== 特性数据 ====================
 const features = [
   { icon: Radio, title: `${stations.length} 精选电台`, description: '涵盖 Lo-Fi、Chill、Jazz、Classical 等多种音乐风格，适合学习、工作、阅读、放松等各种场景', color: '#8B5CF6', bg: 'rgba(139,92,246,0.08)' },
-  { icon: Sparkles, title: '专注计时', description: '记录你的每日专注时长，帮助你培养高效工作习惯，让音乐陪伴你的专注时光', color: '#EC4899', bg: 'rgba(236,72,153,0.08)' },
-  { icon: Waves, title: '在线收听', description: '无需下载安装，打开网页即可享受高品质音乐；灵动岛支持拖动，移动端双击可快速展开，支持快捷键、 PWA 离线使用', color: '#06B6D4', bg: 'rgba(6,182,212,0.08)' },
-  { icon: Moon, title: '睡眠定时', description: '支持 15~120 分钟快速设置定时、1~480 分钟自定义定时，定时结束后自动自动暂停播放，安心入眠无需手动关闭', color: '#F59E0B', bg: 'rgba(245,158,11,0.08)' },
+  { icon: Sparkles, title: '专注计时', description: '记录你的每日专注时长，帮助你培养高效工作习惯，让音乐陪伴你的专注时光', color: '#A855F7', bg: 'rgba(168,85,247,0.08)' },
+  { icon: Waves, title: '在线收听', description: '无需下载安装，打开网页即可享受高品质音乐；灵动岛支持拖动，移动端双击可快速展开，支持快捷键、 PWA 离线使用', color: '#7C3AED', bg: 'rgba(124,58,237,0.08)' },
+  { icon: Moon, title: '睡眠定时', description: '支持 15~120 分钟快速设置定时、1~480 分钟自定义定时，定时结束后自动自动暂停播放，安心入眠无需手动关闭', color: '#9333EA', bg: 'rgba(147,51,234,0.08)' },
 ];
 
 const scenes = [
@@ -434,7 +434,7 @@ export default function Home() {
 
         {/* 高级噪点质感 */}
         <div 
-          className="absolute inset-0 opacity-[0.03] sm:opacity-[0.04]"
+          className="absolute inset-0 opacity-[0.025] sm:opacity-[0.03]"
           style={{ 
             backgroundImage: 'url("data:image/svg+xml,%3Csvg viewBox=\'0 0 200 200\' xmlns=\'http://www.w3.org/2000/svg\'%3E%3Cfilter id=\'noiseFilter\'%3E%3CfeTurbulence type=\'fractalNoise\' baseFrequency=\'0.85\' numOctaves=\'3\' stitchTiles=\'stitch\'/%3E%3C/filter%3E%3Crect width=\'100%25\' height=\'100%25\' filter=\'url(%23noiseFilter)\'/%3E%3C/svg%3E")',
             mixBlendMode: isDark ? 'overlay' : 'multiply'
@@ -442,7 +442,7 @@ export default function Home() {
         />
         <div className="absolute inset-0" style={{
           backgroundImage: `linear-gradient(${isDark ? 'rgba(255,255,255,0.04)' : 'rgba(0,0,0,0.03)'} 1px, transparent 1px), linear-gradient(90deg, ${isDark ? 'rgba(255,255,255,0.04)' : 'rgba(0,0,0,0.03)'} 1px, transparent 1px)`,
-          backgroundSize: '64px 64px', opacity: 0.4,
+          backgroundSize: '64px 64px', opacity: isDark ? 0.25 : 0.4,
         }} />
       </div>
 
@@ -488,7 +488,7 @@ export default function Home() {
               </motion.h1>
 
               {/* 描述 */}
-              <motion.p variants={fadeInUp} className={cn("text-base sm:text-lg md:text-xl max-w-2xl mx-auto mb-10 leading-relaxed", isDark ? "text-white/45" : "text-zinc-500")}>
+              <motion.p variants={fadeInUp} className={cn("text-base sm:text-lg md:text-xl max-w-2xl mx-auto mb-8 leading-relaxed", isDark ? "text-white/45" : "text-zinc-500")}>
                 恰到好处的 Lofi 节拍，陪伴你进入深度专注。
                 <br className="hidden sm:block" />
                 macOS 灵动岛设计，{stations.length} 个精选电台，打开即用，无需下载。
@@ -516,7 +516,7 @@ export default function Home() {
 
               {/* 快捷键 - 仅桌面 */}
               <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 0.7, duration: 0.5 }} className="hidden sm:flex justify-center">
-                <div className={cn("inline-flex items-center gap-4 px-5 py-2.5 rounded-2xl", isDark ? "bg-white/[0.025]" : "bg-black/[0.025]")}>
+                <div className={cn("inline-flex items-center gap-4 px-5 py-2.5 rounded-2xl", isDark ? "bg-white/[0.02]" : "bg-black/[0.02]")}>
                   {shortcuts.map((item, i) => (
                     <div key={i} className="flex items-center gap-1.5">
                       <kbd className={cn("px-2 py-0.5 rounded-md text-xs font-mono font-semibold", isDark ? "bg-white/10 text-white/50 border border-white/10" : "bg-black/5 text-zinc-500 border border-black/8")}>{item.key}</kbd>
@@ -744,7 +744,7 @@ export default function Home() {
 
         {/* 底部 */}
         <footer className={cn(
-          "py-8 px-4 sm:px-6",
+          "mt-4 py-10 px-4 sm:px-6",
           isDark ? "border-t border-white/5" : "border-t border-zinc-100"
         )}>
           <div className="max-w-5xl mx-auto">

--- a/src/components/lofi/floating-player.tsx
+++ b/src/components/lofi/floating-player.tsx
@@ -426,16 +426,10 @@ const FullScreenPlayer = memo(({ onClose, remainingSeconds, suppressVinylTapUnti
       <div 
         className="absolute inset-0 z-0"
         style={{
-          background: `linear-gradient(135deg, 
-            ${stationColor}25 0%, 
-            ${stationColor}10 30%,
-            ${stationColor}08 70%,
-            ${stationColor}18 100%
-          ),
-          linear-gradient(45deg,
-            ${stationColor}10 0%,
-            ${stationColor}15 50%,
-            ${stationColor}10 100%
+          background: `radial-gradient(ellipse at 50% 0%,
+            ${stationColor}20 0%,
+            ${stationColor}0a 45%,
+            transparent 75%
           ),
           rgba(15, 15, 25, 0.95)`,
           backdropFilter: 'blur(40px)',
@@ -513,7 +507,7 @@ const FullScreenPlayer = memo(({ onClose, remainingSeconds, suppressVinylTapUnti
             
             <button
               onClick={togglePlay}
-              className="w-16 h-16 sm:w-18 sm:h-18 rounded-full flex items-center justify-center relative overflow-hidden transition-transform duration-200 hover:scale-105"
+              className="w-16 h-16 sm:w-18 sm:h-18 rounded-full flex items-center justify-center relative overflow-hidden transition-transform duration-200 hover:scale-105 active:scale-95"
               style={{ 
                 background: `linear-gradient(135deg, ${stationColor}, ${stationColor}cc)`,
                 boxShadow: `0 8px 32px ${stationColor}40`
@@ -786,8 +780,8 @@ const MiniPlayer = memo(({ onExpand }: { onExpand: () => void }) => {
           isPlaying ? "opacity-100 animate-breathe" : "opacity-30"
         )}
         style={{ 
-          background: `radial-gradient(ellipse, ${stationColor}40 0%, ${stationColor}15 45%, transparent 70%)`,
-          filter: 'blur(12px)',
+          background: `radial-gradient(ellipse, ${stationColor}33 0%, ${stationColor}12 45%, transparent 70%)`,
+          filter: 'blur(10px)',
         }}
       />
       


### PR DESCRIPTION
## 关联问题

- 关联 Issue / Discussion：N/A（纯 UI 精修，未关联既有 Issue）

## 这次改动做了什么

对首页与播放器做一轮**克制、聚焦的视觉精修**，不改任何功能逻辑、布局结构与交互行为，共 4 个独立 commits，仅触及 3 个文件（`src/app/page.tsx`、`src/components/lofi/floating-player.tsx`、`src/app/globals.css`）：

1. **`fix(ui)` 修复类**
   - 移除 Hero 大标题的 `whitespace-nowrap`，改 `text-balance`，修复窄屏（<360px）标题溢出问题
   - 提升暗色模式辅助文字亮度（`white/30~38 → white/45~55`，约 12 处），改善暗色下可读性（向 WCAG AA 靠拢）
   - 将"Lofi 音乐被科学认证为最适合专注工作学习的音乐"改为克制、可证实的表述（原表述属于无法证实的伪科学宣称，对开源项目可信度有损）

2. **`feat(ui)` Hero 视觉层级**
   - 实时时钟卡片瘦身（padding 与字号各降一档），让大标题重新成为首屏视觉焦点
   - 暗色背景网格与噪点强度下调，减少"脏感"
   - 特性卡片图标色从紫/粉/青/橙四色统一为 violet 品牌色系，消除彩虹感
   - Hero 描述间距收紧、页脚留白增加

3. **`feat(ui)` 播放器细节**
   - 全屏播放器背景由双层叠加线性渐变简化为单层径向渐变（仍跟随电台主题色），画面更干净
   - 主播放按钮补充 `active:scale-95` 按压反馈
   - 灵动岛环境光晕柔化（blur 12→10、不透明度下调），减少播放时屏幕顶部的光污染

4. **`feat(a11y)` 无障碍**
   - 新增 `prefers-reduced-motion: reduce` 支持：停用均衡器、黑胶旋转、呼吸光晕等装饰性动画，均衡器条保留为静态播放状态指示
   - `scroll-behavior: smooth` 仅在用户无动效偏好时启用

## 为什么要这样改

现有页面整体完成度已经很高，主要问题集中在**细节纪律**上：窄屏溢出、暗色对比度不足、无 reduced-motion 降级属于真实缺陷；首屏信息层级拥挤、特性图标色彩杂乱属于视觉精修空间。因此选择"微改"而非改版——保留品牌色、灵动岛交互与全部布局，只修缺陷 + 收敛视觉噪音，每个 commit 主题独立，方便单独 review 或 cherry-pick。

## 验证方式

- [x] 已在本地执行 `npm run lint`
- [x] 已在本地执行 `npm run build`
- [x] 已进行与改动直接相关的手动验证（另执行 `npm run typecheck` 与 `npm test`，8 个测试全部通过）
- [x] 如果改动影响 UI，已附截图或录屏（见下，左为改动前，右为改动后）
- [ ] 如果改动影响文档 / 配置，已同步更新相关说明（不涉及）

### 改动前后对比（左 Before / 右 After）

**桌面端 · 暗色 · 首屏**

![desktop-dark-hero](https://raw.githubusercontent.com/88lin/lofi-radio-web-ui-polish/refine/ui-polish/screenshots/compare_desktop-dark-hero.png)

**桌面端 · 亮色 · 首屏**

![desktop-light-hero](https://raw.githubusercontent.com/88lin/lofi-radio-web-ui-polish/refine/ui-polish/screenshots/compare_desktop-light-hero.png)

**移动端 · 暗色 · 首屏**

![mobile-dark-hero](https://raw.githubusercontent.com/88lin/lofi-radio-web-ui-polish/refine/ui-polish/screenshots/compare_mobile-dark-hero.png)

**桌面端 · 暗色 · 场景/电台区**

![desktop-dark-mid](https://raw.githubusercontent.com/88lin/lofi-radio-web-ui-polish/refine/ui-polish/screenshots/compare_desktop-dark-mid.png)

**桌面端 · 暗色 · FAQ/页脚区**

![desktop-dark-faq](https://raw.githubusercontent.com/88lin/lofi-radio-web-ui-polish/refine/ui-polish/screenshots/compare_desktop-dark-faq.png)

## 补充说明

- Review 优先级建议：commit 1（`fix(ui)`）包含真实缺陷修复，可优先看；其余三个 commit 为纯视觉微调
- 对比截图托管在预览仓库 [88lin/lofi-radio-web-ui-polish](https://github.com/88lin/lofi-radio-web-ui-polish/tree/refine/ui-polish)（与本 PR 分支内容一致），合并后可删除该仓库
- 未覆盖范围：全屏播放器的截图对比因无头浏览器无法加载音频流而未附上，改动仅为背景渐变简化与按钮按压态，风险极低
- 若希望进一步收紧某个改动（例如特性图标保留原四色），commits 已按主题拆分，可单独 revert


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving accessibility and visual enhancements in the CSS and TypeScript files of the application. It implements reduced motion preferences and updates styles for better contrast and clarity.

### Detailed summary
- Added media queries for `prefers-reduced-motion` in `globals.css`.
- Disabled animations for specific classes when motion is reduced.
- Changed background styles in `floating-player.tsx`.
- Adjusted button and text styles for better visibility in `page.tsx`.
- Updated feature descriptions with improved color contrast.
- Modified opacity settings for various elements to enhance readability.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->