### PR TITLE
fix(player): 恢复移动端播放器控件宽度

### DIFF
--- a/src/components/lofi/floating-player.tsx
+++ b/src/components/lofi/floating-player.tsx
@@ -564,10 +564,8 @@ const FullScreenPlayer = memo(({ onClose, remainingSeconds, suppressVinylTapUnti
             </button>
           </div>
           
-          {/* 音量控制。上方电台名 h3 用的是 max-w-sm(384px)，这里和下面的
-              专注/睡眠一行却是 max-w-xs(320px)，导致同一列的轮廓在标题下方
-              收窄 64px。统一为 max-w-sm。 */}
-          <div className="w-full max-w-sm mb-4">
+          {/* 移动端保留 320px 上限，sm 以上再与电台名统一为 384px。 */}
+          <div className="w-full max-w-xs sm:max-w-sm mb-4">
             <div 
               className="px-4 py-3 rounded-2xl"
               style={{ background: 'rgba(255, 255, 255, 0.04)' }}
@@ -583,7 +581,7 @@ const FullScreenPlayer = memo(({ onClose, remainingSeconds, suppressVinylTapUnti
           </div>
           
           {/* 专注时间 + 睡眠定时器 */}
-          <div className="grid grid-cols-2 gap-2 w-full max-w-sm">
+          <div className="grid grid-cols-2 gap-2 w-full max-w-xs sm:max-w-sm">
             {/* 专注时间 */}
             <div 
               className="flex items-center justify-center gap-1 px-1 py-2 rounded-full whitespace-nowrap"


### PR DESCRIPTION
## 修改内容

- 音量控制区在移动端恢复 `max-w-xs`（320px）上限
- “今日专注 / 睡眠定时”按钮组同步恢复 320px 上限
- `sm` 及以上继续使用 `max-w-sm`（384px），保留 PR #12 的桌面对齐效果

## 根因

PR #12 将两处 `max-w-xs` 直接改成了无断点的 `max-w-sm`。这导致 375px 屏幕上的容器扩展到整屏，390px 屏幕左右只剩 3px，看起来被拉宽并贴近屏幕边缘。

## 验证

- 375px：375px / 0px 边距 → 320px / 27.5px 边距
- 390px：384px / 3px 边距 → 320px / 35px 边距
- 430px：384px / 23px 边距 → 320px / 55px 边距
- 1440px：保持 384px
- 所有视口横向溢出均为 0
- `npm run lint`
- `npm run typecheck`
- `npm test`（8/8）
- `npm run build`


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the responsiveness of the layout in the `floating-player.tsx` component by adjusting the maximum width settings for different screen sizes.

### Detailed summary
- Updated the maximum width for the main container from `max-w-sm` (384px) to `max-w-xs` (320px) for mobile devices, while maintaining `sm:max-w-sm` for larger screens.
- Changed the maximum width of the grid container from `max-w-sm` to `max-w-xs sm:max-w-sm`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->